### PR TITLE
Remove leading space from keywords.txt identifier

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,17 +6,17 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-X_Nucleo_NFC04 KEYWORD1
+X_Nucleo_NFC04	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin 		KEYWORD2
-ledOn 		KEYWORD2
-ledOff 		KEYWORD2
-writeURI 	KEYWORD2
-readURI 	KEYWORD2
+begin	KEYWORD2
+ledOn	KEYWORD2
+ledOff	KEYWORD2
+writeURI	KEYWORD2
+readURI	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords