### PR TITLE
Fix build and run on AVR

### DIFF
--- a/examples/X_NUCLEO_NFC04A1_HelloWorld/X_NUCLEO_NFC04A1_HelloWorld.ino
+++ b/examples/X_NUCLEO_NFC04A1_HelloWorld/X_NUCLEO_NFC04A1_HelloWorld.ino
@@ -1,62 +1,62 @@
 /**
  ******************************************************************************
- * @file    X_NUCLEO_NFC04A1_HelloWorld.ino
- * @author  STMicroelectronics
- * @version V1.0.0
- * @date    22 November 2017
- * @brief   Arduino test application for the STMicrolectronics
- *          X-NUCLEO-NFC04A1. NFC tag based on ST25DV device.
- *          This application makes use of C++ classes obtained from the C
- *          components' drivers.
+   @file    X_NUCLEO_NFC04A1_HelloWorld.ino
+   @author  STMicroelectronics
+   @version V1.0.0
+   @date    22 November 2017
+   @brief   Arduino test application for the STMicrolectronics
+            X-NUCLEO-NFC04A1. NFC tag based on ST25DV device.
+            This application makes use of C++ classes obtained from the C
+            components' drivers.
  ******************************************************************************
- * @attention
- *
- * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright notice,
- *      this list of conditions and the following disclaimer in the documentation
- *      and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its contributors
- *      may be used to endorse or promote products derived from this software
- *      without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- ******************************************************************************
- */
+   @attention
 
- /**
+   <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+
+   Redistribution and use in source and binary forms, with or without modification,
+   are permitted provided that the following conditions are met:
+     1. Redistributions of source code must retain the above copyright notice,
+        this list of conditions and the following disclaimer.
+     2. Redistributions in binary form must reproduce the above copyright notice,
+        this list of conditions and the following disclaimer in the documentation
+        and/or other materials provided with the distribution.
+     3. Neither the name of STMicroelectronics nor the names of its contributors
+        may be used to endorse or promote products derived from this software
+        without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+   CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+   OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
  ******************************************************************************
-* How to use this sketch
-*
-* This sketch uses the I2C interface to communicate with the NFC device.
-* It writes an NFC tag type URI (Uniform Resource Identifier) and reads this same tag.
-* Choose the uri by changing the content of uri_write.
-*
-* When the NFC module is started and ready, the message "Sytstem init done!" is
-* displayed on the monitor window. Next, the tag is written, read and printed on
-* the monitor window.
-*
-* You can also use your smartphone to read/write a tag.
-* On Android, donwload a NFC Tools. Then start the app, check if NFC is activated
-* on your smartphone. Put your smartphone near the tag, you can read it. You can
-* write a tag with this app.
- ******************************************************************************
- */
- 
+*/
+
+/**
+******************************************************************************
+  How to use this sketch
+
+  This sketch uses the I2C interface to communicate with the NFC device.
+  It writes an NFC tag type URI (Uniform Resource Identifier) and reads this same tag.
+  Choose the uri by changing the content of uri_write.
+
+  When the NFC module is started and ready, the message "Sytstem init done!" is
+  displayed on the monitor window. Next, the tag is written, read and printed on
+  the monitor window.
+
+  You can also use your smartphone to read/write a tag.
+  On Android, donwload a NFC Tools. Then start the app, check if NFC is activated
+  on your smartphone. Put your smartphone near the tag, you can read it. You can
+  write a tag with this app.
+******************************************************************************
+*/
+
 #include "x_nucleo_nfc04.h"
 
 #define SerialPort      Serial
@@ -70,31 +70,31 @@ void setup() {
   // Initialize serial for output.
   SerialPort.begin(115200);
 
-  if(X_Nucleo_Nfc04.begin() == 0) {
+  if (X_Nucleo_Nfc04.begin() == 0) {
     SerialPort.println("System Init done!");
     X_Nucleo_Nfc04.ledOn(GREEN_LED);
   } else {
     SerialPort.println("System Init failed!");
-    while(1);
+    while (1);
   }
 
-  if(X_Nucleo_Nfc04.writeURI(uri_write_protocol, uri_write_message, "")) {
+  if (X_Nucleo_Nfc04.writeURI(uri_write_protocol, uri_write_message, "")) {
     SerialPort.println("Write failed!");
-    while(1);
+    while (1);
   }
 
   X_Nucleo_Nfc04.ledOn(BLUE_LED);
 
   delay(100);
-  
-  if(X_Nucleo_Nfc04.readURI(&uri_read)) {
+
+  if (X_Nucleo_Nfc04.readURI(&uri_read)) {
     SerialPort.println("Read failed!");
-    while(1);
+    while (1);
   }
 
   SerialPort.println(uri_read.c_str());
 
-  if(strcmp(uri_read.c_str(), uri_write.c_str()) == 0) {
+  if (strcmp(uri_read.c_str(), uri_write.c_str()) == 0) {
     SerialPort.println("Successfully written and read!");
     X_Nucleo_Nfc04.ledOn(YELLOW_LED);
   } else {
@@ -102,6 +102,6 @@ void setup() {
   }
 }
 
-void loop() {  
+void loop() {
   //empty loop
-} 
+}

--- a/examples/X_NUCLEO_NFC04A1_HelloWorld/X_NUCLEO_NFC04A1_HelloWorld.ino
+++ b/examples/X_NUCLEO_NFC04A1_HelloWorld/X_NUCLEO_NFC04A1_HelloWorld.ino
@@ -46,9 +46,11 @@
   It writes an NFC tag type URI (Uniform Resource Identifier) and reads this same tag.
   Choose the uri by changing the content of uri_write.
 
-  When the NFC module is started and ready, the message "Sytstem init done!" is
-  displayed on the monitor window. Next, the tag is written, read and printed on
-  the monitor window.
+  When the NFC module is started and ready, the green LED switches ON else it blinks.
+  Next, the tag is written, the blue LED switches ON else it blinks.
+  Then read is performed, the yellow LED switches ON else it blinks.
+  Finally, the written and read value are compared, if they does not match then
+  all LED's blink.
 
   You can also use your smartphone to read/write a tag.
   On Android, donwload a NFC Tools. Then start the app, check if NFC is activated
@@ -59,28 +61,29 @@
 
 #include "x_nucleo_nfc04.h"
 
-#define SerialPort      Serial
-
 void setup() {
   const char uri_write_message[] = "st.com/st25";       // Uri message to write in the tag
   const char uri_write_protocol[] = URI_ID_0x01_STRING; // Uri protocol to write in the tag
   String uri_write = String(uri_write_protocol) + String(uri_write_message);
   String uri_read;
 
-  // Initialize serial for output.
-  SerialPort.begin(115200);
-
-  if (X_Nucleo_Nfc04.begin() == 0) {
-    SerialPort.println("System Init done!");
-    X_Nucleo_Nfc04.ledOn(GREEN_LED);
-  } else {
-    SerialPort.println("System Init failed!");
-    while (1);
+  if (X_Nucleo_Nfc04.begin()) {
+    while (1) {
+      X_Nucleo_Nfc04.ledOn(GREEN_LED);
+      delay(100);
+      X_Nucleo_Nfc04.ledOff(GREEN_LED);
+      delay(100);
+    }
   }
+  X_Nucleo_Nfc04.ledOn(GREEN_LED);
 
   if (X_Nucleo_Nfc04.writeURI(uri_write_protocol, uri_write_message, "")) {
-    SerialPort.println("Write failed!");
-    while (1);
+    while (1) {
+      X_Nucleo_Nfc04.ledOn(BLUE_LED);
+      delay(100);
+      X_Nucleo_Nfc04.ledOff(BLUE_LED);
+      delay(100);
+    }
   }
 
   X_Nucleo_Nfc04.ledOn(BLUE_LED);
@@ -88,17 +91,27 @@ void setup() {
   delay(100);
 
   if (X_Nucleo_Nfc04.readURI(&uri_read)) {
-    SerialPort.println("Read failed!");
-    while (1);
+    while (1) {
+      X_Nucleo_Nfc04.ledOn(YELLOW_LED);
+      delay(100);
+      X_Nucleo_Nfc04.ledOff(YELLOW_LED);
+      delay(100);
+    }
   }
 
-  SerialPort.println(uri_read.c_str());
+  X_Nucleo_Nfc04.ledOn(YELLOW_LED);
 
-  if (strcmp(uri_read.c_str(), uri_write.c_str()) == 0) {
-    SerialPort.println("Successfully written and read!");
-    X_Nucleo_Nfc04.ledOn(YELLOW_LED);
-  } else {
-    SerialPort.println("Read bad string!");
+  if (strcmp(uri_read.c_str(), uri_write.c_str()) != 0) {
+    while (1) {
+      X_Nucleo_Nfc04.ledOn(GREEN_LED);
+      X_Nucleo_Nfc04.ledOn(BLUE_LED);
+      X_Nucleo_Nfc04.ledOn(YELLOW_LED);
+      delay(100);
+      X_Nucleo_Nfc04.ledOff(GREEN_LED);
+      X_Nucleo_Nfc04.ledOff(BLUE_LED);
+      X_Nucleo_Nfc04.ledOff(YELLOW_LED);
+      delay(100);
+    }
   }
 }
 

--- a/examples/X_NUCLEO_NFC04A1_SimpleWrite/X_NUCLEO_NFC04A1_SimpleWrite.ino
+++ b/examples/X_NUCLEO_NFC04A1_SimpleWrite/X_NUCLEO_NFC04A1_SimpleWrite.ino
@@ -1,62 +1,62 @@
 /**
  ******************************************************************************
- * @file    X_NUCLEO_NFC04A1_SimpleWrite.ino
- * @author  STMicroelectronics
- * @version V1.0.0
- * @date    22 November 2017
- * @brief   Arduino test application for the STMicrolectronics
- *          X-NUCLEO-NFC04A1. NFC tag based on ST25DV device.
- *          This application makes use of C++ classes obtained from the C
- *          components' drivers.
+   @file    X_NUCLEO_NFC04A1_SimpleWrite.ino
+   @author  STMicroelectronics
+   @version V1.0.0
+   @date    22 November 2017
+   @brief   Arduino test application for the STMicrolectronics
+            X-NUCLEO-NFC04A1. NFC tag based on ST25DV device.
+            This application makes use of C++ classes obtained from the C
+            components' drivers.
  ******************************************************************************
- * @attention
- *
- * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- *   1. Redistributions of source code must retain the above copyright notice,
- *      this list of conditions and the following disclaimer.
- *   2. Redistributions in binary form must reproduce the above copyright notice,
- *      this list of conditions and the following disclaimer in the documentation
- *      and/or other materials provided with the distribution.
- *   3. Neither the name of STMicroelectronics nor the names of its contributors
- *      may be used to endorse or promote products derived from this software
- *      without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- ******************************************************************************
- */
+   @attention
 
- /**
+   <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+
+   Redistribution and use in source and binary forms, with or without modification,
+   are permitted provided that the following conditions are met:
+     1. Redistributions of source code must retain the above copyright notice,
+        this list of conditions and the following disclaimer.
+     2. Redistributions in binary form must reproduce the above copyright notice,
+        this list of conditions and the following disclaimer in the documentation
+        and/or other materials provided with the distribution.
+     3. Neither the name of STMicroelectronics nor the names of its contributors
+        may be used to endorse or promote products derived from this software
+        without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+   CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+   OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
  ******************************************************************************
-* How to use this sketch
-*
-* This sketch uses the I2C interface to communicate with the NFC device.
-* It writes an NFC tag type URI (Uniform Resource Identifier).
-* Choose the uri by changing the content of uri_write.
-*
-* When the NFC module is started and ready, the message "Sytstem init done!" is
-* displayed on the monitor window. Next, the tag is written with the content 
-* printed on the monitor window.
-*
-* You can use your smartphone to read the tag.
-* On Android, check if NFC is activated on your smartphone. 
-* Put your smartphone near the tag to natively read it. 
-* The prefered Internet Browser is automatically opened with the provided URI.
- ******************************************************************************
- */
- 
+*/
+
+/**
+******************************************************************************
+  How to use this sketch
+
+  This sketch uses the I2C interface to communicate with the NFC device.
+  It writes an NFC tag type URI (Uniform Resource Identifier).
+  Choose the uri by changing the content of uri_write.
+
+  When the NFC module is started and ready, the message "Sytstem init done!" is
+  displayed on the monitor window. Next, the tag is written with the content
+  printed on the monitor window.
+
+  You can use your smartphone to read the tag.
+  On Android, check if NFC is activated on your smartphone.
+  Put your smartphone near the tag to natively read it.
+  The prefered Internet Browser is automatically opened with the provided URI.
+******************************************************************************
+*/
+
 #include "x_nucleo_nfc04.h"
 
 #define SerialPort      Serial
@@ -69,23 +69,23 @@ void setup() {
   // Initialize serial for output.
   SerialPort.begin(115200);
 
-  if(X_Nucleo_Nfc04.begin() == 0) {
+  if (X_Nucleo_Nfc04.begin() == 0) {
     SerialPort.println("System Init done!");
     X_Nucleo_Nfc04.ledOn(GREEN_LED);
   } else {
     SerialPort.println("System Init failed!");
-    while(1);
+    while (1);
   }
 
-  if(X_Nucleo_Nfc04.writeURI(uri_write_protocol, uri_write_message, "")) {
+  if (X_Nucleo_Nfc04.writeURI(uri_write_protocol, uri_write_message, "")) {
     SerialPort.println("Write failed!");
-    while(1);
+    while (1);
   }
 
   X_Nucleo_Nfc04.ledOn(BLUE_LED);
 
 }
 
-void loop() {  
+void loop() {
   //empty loop
-} 
+}

--- a/src/BSP/x_nucleo_nfc04a1.cpp
+++ b/src/BSP/x_nucleo_nfc04a1.cpp
@@ -76,9 +76,9 @@ void NFC04A1_LED_Init(void)
   * @param  Led: LED to be de-init.
   * @note Led DeInit does not disable the GPIO clock nor disable the Mfx
   */
-void NFC04A1_LED_DeInit(NFC04A1_Led_E led)
+void NFC04A1_LED_DeInit(NFC04A1_Led_E /*led*/)
 {
-  UNUSED(led);
+
 }
 
 /**


### PR DESCRIPTION
This PR solved #10
* build issue on AVR target due to `UNUSED` was not recognized
* Rework `X_NUCLEO_NFC04A1_HelloWorld.ino` to be able to run on target with small RAM.

